### PR TITLE
Split zabbix_url and Apache vhost ServerName

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ agent_serveractive:
 zabbix_selinux: False
 
 zabbix_url: zabbix.example.com
+zabbix_apache_servername: "{{ zabbix_url | regex_findall('(?:https?\\://)?([\\w\\.]+)') | first }}"
 zabbix_url_aliases: []
 zabbix_apache_vhost_port: 80
 zabbix_timezone: Europe/Amsterdam

--- a/templates/apache_vhost.conf.j2
+++ b/templates/apache_vhost.conf.j2
@@ -1,5 +1,5 @@
 <VirtualHost *:{{ zabbix_apache_vhost_port }}>
-  ServerName {{ zabbix_url }}
+  ServerName {{ zabbix_apache_servername }}
   {% for alias in zabbix_url_aliases %}
   ServerAlias {{ alias }}
   {% endfor %}
@@ -34,9 +34,9 @@
 
 {% endfor %}
   ## Logging
-  ErrorLog "/var/log/{{ apache_log }}/{{ zabbix_url }}_error.log"
+  ErrorLog "/var/log/{{ apache_log }}/{{ zabbix_apache_servername }}_error.log"
   ServerSignature Off
-  CustomLog "/var/log/{{ apache_log }}/{{ zabbix_url }}_access.log" combined
+  CustomLog "/var/log/{{ apache_log }}/{{ zabbix_apache_servername }}_access.log" combined
 
   ## Rewrite rules
   RewriteEngine On


### PR DESCRIPTION
Variable zabbix_url clashes with zabbix-agent where it is contains real URL instead of server name.
In this change we are extract host name from zabbix_url if it in URL format or take it as is. Default behavior not changed.