### PR TITLE
Fix Zabbix graph legend bug for Debian packages (see ZBX-10467)

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -61,6 +61,16 @@
     - init
     - config
 
+- name: "Debian | Link graphfont.ttf (workaround ZBX-10467)"
+  file:
+    src: '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf' # Part of ttf-dejavu-core package installed as dependencies
+    path: '/usr/share/zabbix/fonts/graphfont.ttf'
+    state: link
+  tags:
+    - zabbix-web
+    - init
+    - config
+
 - name: "Debian | install apache vhost"
   template:
     src: apache_vhost.conf.j2


### PR DESCRIPTION
Tested on Ubuntu 16.04 and Zabbix 3.4.2.

If font already preset this fix is not override them.