### PR TITLE
Fixed missing attribute iteritems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,8 +36,6 @@ zabbix_web_post_max_size: 16M
 zabbix_web_upload_max_filesize: 2M
 zabbix_web_max_input_time: 300
 
-zabbix_web_env: []
-
 database_type: pgsql
 database_type_long: postgresql
 

--- a/templates/zabbix.conf.php.j2
+++ b/templates/zabbix.conf.php.j2
@@ -18,7 +18,9 @@ $ZBX_SERVER_NAME = '{{ zabbix_server_name }}';
 
 $IMAGE_FORMAT_DEFAULT = IMAGE_FORMAT_PNG;
 
+{% if zabbix_web_env is defined %}
 {% for env,val in zabbix_web_env.iteritems() %}
 putenv("{{env}}={{val}}")
 {% endfor %}
+{% endif %}
 ?>


### PR DESCRIPTION
Fix for introduced bug in latest commit.
```
fatal: [zabbix-web-pgsql-debian]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'list object' has no attribute 'iteritems'"}```