### PR TITLE
Most of the time php behaves better with leading semicolon.

### DIFF
--- a/templates/zabbix.conf.php.j2
+++ b/templates/zabbix.conf.php.j2
@@ -20,7 +20,7 @@ $IMAGE_FORMAT_DEFAULT = IMAGE_FORMAT_PNG;
 
 {% if zabbix_web_env is defined %}
 {% for env,val in zabbix_web_env.iteritems() %}
-putenv("{{env}}={{val}}")
+putenv("{{env}}={{val}}");
 {% endfor %}
 {% endif %}
 ?>


### PR DESCRIPTION
Doing Python most of the time pays its toll.