### PR TITLE
Renamed php5-* to php-*

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -23,9 +23,9 @@
     - init
     - config
 
-- name: "Debian | Install php5-{{ database_type }}"
+- name: "Debian | Install php-{{ database_type }}"
   apt:
-    pkg: php5-{{ database_type }}
+    pkg: php-{{ database_type }}
     state: present
     update_cache: yes
     cache_valid_time: 3600


### PR DESCRIPTION
Renamed php5-* to php-* because php5-* no longer exists.