### PR TITLE
Changed version_compare operator to avoid deprecation warnings

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -30,8 +30,8 @@
     update_cache: yes
     cache_valid_time: 3600
   when: >
-    ( ansible_distribution == 'Ubuntu' and (ansible_distribution_version | version_compare('16.04', '<')))
-    or ( ansible_distribution == 'Debian' and (ansible_distribution_version | version_compare('9.0', '<')) )
+    ( ansible_distribution == 'Ubuntu' and (ansible_distribution_version is version_compare('16.04', '<')))
+    or ( ansible_distribution == 'Debian' and (ansible_distribution_version is version_compare('9.0', '<')) )
   tags:
     - zabbix-web
     - init
@@ -44,8 +44,8 @@
     cache_valid_time: 3600
   with_items: "{{ ubuntu_packages }}"
   when: >
-    ( ansible_distribution == 'Ubuntu' and (ansible_distribution_version | version_compare('16.04', '>=')))
-    or ( ansible_distribution == 'Debian' and (ansible_distribution_version | version_compare('9.0', '>=')) )
+    ( ansible_distribution == 'Ubuntu' and (ansible_distribution_version is version_compare('16.04', '>=')))
+    or ( ansible_distribution == 'Debian' and (ansible_distribution_version is version_compare('9.0', '>=')) )
   tags:
     - zabbix-server
     - init


### PR DESCRIPTION
Hi @dj-wasabi,

As i said in the previous PR, i changed this operator to avoid this warning deprecation message. 

Regards, 