### PR TITLE
Make debian 9 work

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,14 +23,16 @@ platforms:
     privileged: True
     groups:
       - postgresql
-  - name: zabbix-web-mysql-debian
-    image: maint/debian-systemd
-    privileged: True
-    groups:
-      - mysql
   - name: zabbix-web-pgsql-debian
-    image: maint/debian-systemd
+    image: minimum2scp/systemd-stretch
     privileged: True
+    command: /sbin/init
+    groups:
+      - postgresql
+  - name: zabbix-web-pgsql-debian
+    image: minimum2scp/systemd-stretch
+    privileged: True
+    command: /sbin/init
     groups:
       - postgresql
   - name: zabbix-web-mysql-ubuntu
@@ -53,12 +55,12 @@ provisioner:
   inventory:
     group_vars:
       mysql:
-        database_type: mysql
-        database_type_long: mysql
-        server_dbport: 3306
+        zabbix_server_database: mysql
+        zabbix_server_database_long: mysql
+        zabbix_server_dbport: 3306
       postgresql:
-        database_type: pgsql
-        database_type_long: postgresql
+        zabbix_server_database: pgsql
+        zabbix_server_database_long: postgresql
     host_vars:
       zabbix-web-pgsql-debian:
         zabbix_url: zabbix-web-pgsql-debian

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,13 +5,13 @@
     - name: "Installing EPEL"
       yum:
         name: epel-release
-        state: installed
+        state: present
       when: ansible_distribution == 'CentOS'
 
     - name: "Installing packages"
       yum:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - net-tools
         - which
@@ -23,7 +23,7 @@
     - name: "Installing which on NON-CentOS"
       apt:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - net-tools
         - python-pip

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,10 +1,19 @@
 ---
 
+- name: "Include Zabbix gpg ids"
+  include_vars: zabbix.yml
+
+- name: "Set short version name"
+  set_fact:
+    zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
+
 - name: "Debian | Install gpg key"
   apt_key:
-    id: 79EA5ED4
+    id: "{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
     url: http://repo.zabbix.com/zabbix-official-repo.key
-  when: zabbix_repo == "zabbix"
+  when:
+    - zabbix_repo == "zabbix"
+  become: yes
   tags:
     - zabbix-web
     - init

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -1,0 +1,80 @@
+---
+
+sign_keys:
+  "34":
+    bionic:
+      sign_key: A14FE591
+    sonya:
+      sign_key: A14FE591
+    serena:
+      sign_key: A14FE591
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "32":
+    sonya:
+      sign_key: 79EA5ED4
+    serena:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "30":
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "24":
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    precise:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+  "22":
+    squeeze:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    precise:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    lucid:
+      sign_key: 79EA5ED4
+
+suse:
+  "openSUSE Leap":
+    "42":
+      name: server:monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/openSUSE_Leap_{{ ansible_distribution_version }}/
+  "openSUSE":
+    "12":
+      name: server_monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/openSUSE_{{ ansible_distribution_version }}
+  "SLES":
+    "11":
+      name: server_monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/SLE_11_SP3/


### PR DESCRIPTION
This PR contains the following changes:

* Make it work with Zabbix-Server 1.1.0;
* Make it work with Debian 9, fixes: #20
