### PR TITLE
Always include OS variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,8 @@
 
 - name: "Include OS-specific variables"
   include_vars: "{{ ansible_os_family }}.yml"
+  tags:
+    - always
 
 - name: "Set short version name"
   set_fact:


### PR DESCRIPTION
**Description of PR**

Add tag "always" to task that includes OS-specific variables.

**Type of change**

Bugfix Pull Request

**Fixes an issue**

Resolves bug where passing "zabbix-web" tag at command line fails for Ubuntu hosts due to missing OS variables.
