### PR TITLE
Fix apt module deprecation notice

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -47,11 +47,10 @@
 
 - name: "Ubuntu | Install php7-{{ zabbix_server_database }}"
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ ubuntu_packages }}"
     state: present
     update_cache: yes
     cache_valid_time: 3600
-  with_items: "{{ ubuntu_packages }}"
   when: >
     ( ansible_distribution == 'Ubuntu' and (ansible_distribution_version is version_compare('16.04', '>=')))
     or ( ansible_distribution == 'Debian' and (ansible_distribution_version is version_compare('9.0', '>=')) )


### PR DESCRIPTION
Ansible apt module now accepts a list of packages, fix deprecation
notice:

[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `pkg: "{{ item }}"`, please use `pkg: '{{ ubuntu_packages }}'`
and remove the loop. This feature will be removed in version 2.11.

**Description of PR**
<!--- Describe what the PR holds -->

**Type of change**
<!--- Pick one below and delete the rest: -->

Feature Pull Request
Bugfix Pull Request
Docs Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
