### PR TITLE
fix apache servername regex to support hyphen character

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ zabbix_web_package_state: present
 zabbix_selinux: False
 
 zabbix_url: zabbix.example.com
-zabbix_apache_servername: "{{ zabbix_url | regex_findall('(?:https?\\://)?([\\w\\.]+)') | first }}"
+zabbix_apache_servername: "{{ zabbix_url | regex_findall('(?:https?\\://)?([\\w\\-\\.]+)') | first }}"
 zabbix_url_aliases: []
 zabbix_apache_vhost_port: 80
 zabbix_apache_vhost_tls_port: 443


### PR DESCRIPTION
**Description of PR**
We had an issue with the `zabbix_apache_servername` variable when `zabbix_url` contained the hyphen (-) character.

For example, if you have the following Zabbix url: _myhost.my-domain.tld_
Before this fix, this resulted in _myhost.my_
After this fix, this will result in _myhost.my-domain.tld_

**Type of change**
Bugfix Pull Request