### PR TITLE
Make Apache optional but keep as default; Closes dj-wasabi/ansible-zabbix-web#58

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ zabbix_repo_yum:
 
 # Dependencies
 
-This role has one "hardcoded" dependency: geerlingguy.apache.
+This role has one dependency for Apache usage: geerlingguy.apache. Via the variable zabbix_websrv != 'apache' this can be skipped.
 
 As it is also possible to run the zabbix-web on a different host than the zabbix-server, the zabbix-server is not configured to be an dependency.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,8 @@ zabbix_web_package_state: present
 zabbix_selinux: False
 
 zabbix_url: zabbix.example.com
-zabbix_apache_servername: "{{ zabbix_url | regex_findall('(?:https?\\://)?([\\w\\-\\.]+)') | first }}"
+zabbix_websrv: apache
+zabbix_websrv_servername: "{{ zabbix_url | regex_findall('(?:https?\\://)?([\\w\\-\\.]+)') | first }}"
 zabbix_url_aliases: []
 zabbix_apache_vhost_port: 80
 zabbix_apache_vhost_tls_port: 443

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,4 +26,4 @@ galaxy_info:
     - zabbix
 
 dependencies:
-  - {name: geerlingguy.apache, src: geerlingguy.apache, tags: apache}
+  - { role: geerlingguy.apache, src: geerlingguy.apache, tags: apache, when: zabbix_websrv == 'apache' }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,4 +26,7 @@ galaxy_info:
     - zabbix
 
 dependencies:
-  - { role: geerlingguy.apache, src: geerlingguy.apache, tags: apache, when: zabbix_websrv == 'apache' }
+  - name: geerlingguy.apache
+    src: git+https://github.com/geerlingguy/ansible-role-apache.git
+    tags: apache
+    when: zabbix_websrv == 'apache'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,6 +27,6 @@ galaxy_info:
 
 dependencies:
   - name: geerlingguy.apache
-    src: git+https://github.com/geerlingguy/ansible-role-apache.git
+    src: geerlingguy.apache
     tags: apache
     when: zabbix_websrv == 'apache'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -64,22 +64,22 @@ provisioner:
     host_vars:
       zabbix-web-pgsql-debian:
         zabbix_url: zabbix-web-pgsql-debian
-        zabbix_apache_servername: zabbix-web-pgsql-debian
+        zabbix_websrv_servername: zabbix-web-pgsql-debian
       zabbix-web-mysql-debian:
         zabbix_url: zabbix-web-mysql-debian
-        zabbix_apache_servername: zabbix-web-mysql-debian
+        zabbix_websrv_servername: zabbix-web-mysql-debian
       zabbix-web-pgsql-centos:
         zabbix_url: zabbix-web-pgsql-centos
-        zabbix_apache_servername: zabbix-web-pgsql-centos
+        zabbix_websrv_servername: zabbix-web-pgsql-centos
       zabbix-web-mysql-centos:
         zabbix_url: zabbix-web-mysql-centos
-        zabbix_apache_servername: zabbix-web-mysql-centos
+        zabbix_websrv_servername: zabbix-web-mysql-centos
       zabbix-web-mysql-ubuntu:
         zabbix_url: zabbix-web-mysql-ubuntu
-        zabbix_apache_servername: zabbix-web-mysql-ubuntu
+        zabbix_websrv_servername: zabbix-web-mysql-ubuntu
       zabbix-web-pgsql-ubuntu:
         zabbix_url: zabbix-web-pgsql-ubuntu
-        zabbix_apache_servername: zabbix-web-pgsql-ubuntu
+        zabbix_websrv_servername: zabbix-web-pgsql-ubuntu
 
 scenario:
   name: default

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -86,42 +86,7 @@
     - init
     - config
 
-- name: "Debian | install apache vhost"
-  template:
-    src: apache_vhost.conf.j2
-    dest: /etc/apache2/sites-available/zabbix.conf
-    owner: "{{ apache_user }}"
-    group: "{{ apache_group }}"
-    mode: 0644
-  when: zabbix_vhost
-  notify:
-    - restart apache
-  tags:
-    - zabbix-web
-    - init
-    - config
-    - apache
-
-- name: "Remove provided zabbix.conf files"
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - /etc/apache2/conf-available/zabbix.conf
-    - /etc/apache2/conf-enabled/zabbix.conf
-
-- name: "Debian | enable apache vhost"
-  file:
-    src: /etc/apache2/sites-available/zabbix.conf
-    dest: /etc/apache2/sites-enabled/zabbix.conf
-    owner: "{{ apache_user }}"
-    group: "{{ apache_group }}"
-    state: link
-  when: zabbix_vhost
-  notify:
-    - restart apache
-  tags:
-    - zabbix-server
-    - init
-    - config
-    - apache
+- include_tasks: apache_Debian.yml
+  vars:
+    zabbix_apache_servername: "{{ zabbix_websrv_servername }}"
+  when: zabbix_websrv == 'apache'

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -24,15 +24,7 @@
   tags:
     - zabbix-web
 
-- name: "RedHat | Install apache vhost"
-  template:
-    src: apache_vhost.conf.j2
-    dest: /etc/httpd/conf.d/zabbix.conf
-    owner: "{{ apache_user }}"
-    group: "{{ apache_group }}"
-    mode: 0644
-  when: zabbix_vhost
-  notify:
-    - restart apache
-  tags:
-    - zabbix-server
+- include_tasks: apache_RedHat.yml
+  vars:
+    zabbix_apache_servername: "{{ zabbix_websrv_servername }}"
+  when: zabbix_websrv == 'apache'

--- a/tasks/apache.yml
+++ b/tasks/apache.yml
@@ -1,0 +1,18 @@
+---
+- name: "Apache | Get Apache version"
+  shell: |
+    set -o pipefail
+    apachectl -v | grep 'version' | awk -F '/' '{ print $2 }'| awk '{ print $1 }' | cut -c 1-3
+  changed_when: False
+  register: apachectl_version
+  check_mode: no
+  args:
+    executable: /bin/bash
+  tags:
+    - zabbix-web
+
+- name: "Apache | Set correct apache_version"
+  set_fact:
+    apache_version: "{{ apachectl_version.stdout }}"
+  tags:
+    - zabbix-web

--- a/tasks/apache_Debian.yml
+++ b/tasks/apache_Debian.yml
@@ -1,0 +1,40 @@
+---
+- name: "Debian | install apache vhost"
+  template:
+    src: apache_vhost.conf.j2
+    dest: /etc/apache2/sites-available/zabbix.conf
+    owner: "{{ apache_user }}"
+    group: "{{ apache_group }}"
+    mode: 0644
+  when: zabbix_vhost
+  notify:
+    - restart apache
+  tags:
+    - zabbix-web
+    - init
+    - config
+    - apache
+
+- name: "Debian | Remove provided zabbix.conf files"
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /etc/apache2/conf-available/zabbix.conf
+    - /etc/apache2/conf-enabled/zabbix.conf
+
+- name: "Debian | enable apache vhost"
+  file:
+    src: /etc/apache2/sites-available/zabbix.conf
+    dest: /etc/apache2/sites-enabled/zabbix.conf
+    owner: "{{ apache_user }}"
+    group: "{{ apache_group }}"
+    state: link
+  when: zabbix_vhost
+  notify:
+    - restart apache
+  tags:
+    - zabbix-server
+    - init
+    - config
+    - apache

--- a/tasks/apache_RedHat.yml
+++ b/tasks/apache_RedHat.yml
@@ -1,0 +1,13 @@
+---
+- name: "RedHat | Install apache vhost"
+  template:
+    src: apache_vhost.conf.j2
+    dest: /etc/httpd/conf.d/zabbix.conf
+    owner: "{{ apache_user }}"
+    group: "{{ apache_group }}"
+    mode: 0644
+  when: zabbix_vhost
+  notify:
+    - restart apache
+  tags:
+    - zabbix-server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,23 +12,8 @@
   tags:
     - always
 
-- name: "Get Apache version"
-  shell: |
-    set -o pipefail
-    apachectl -v | grep 'version' | awk -F '/' '{ print $2 }'| awk '{ print $1 }' | cut -c 1-3
-  changed_when: False
-  register: apachectl_version
-  check_mode: no
-  args:
-    executable: /bin/bash
-  tags:
-    - zabbix-web
-
-- name: "Set correct apache_version"
-  set_fact:
-    apache_version: "{{ apachectl_version.stdout }}"
-  tags:
-    - zabbix-web
+- include_tasks: apache.yml
+  when: zabbix_websrv == 'apache'
 
 - name: "Install the correct repository"
   include: "RedHat.yml"


### PR DESCRIPTION
**Description of PR**
Keeping default functionality but splitting the Apache tasks into switchable include_tasks.
Abstracting the zabbix_apache_servername variable but setting it for the Apache tasks.
Remove the hardcode role dependency for making it optional. Update README about it.

**Type of change**

Feature Pull Request

**Fixes an issue**

https://github.com/dj-wasabi/ansible-zabbix-web/issues/58
