### PR TITLE
adding zabbix_apache_skip_custom_fragment to prevent php_values in conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_post_max_size`:
 * `zabbix_web_upload_max_filesize`:
 * `zabbix_web_max_input_time`:
+* `zabbix_apache_skip_custom_fragment`: True / False. Skips adding of php_value vars max_execution_time, memory_limit, post_max_size, upload_max_filesize, max_input_time and date.timezone in vhost file.. place those in php-fpm configuration. Default is false
 * `zabbix_web_env`: (Optional) A Dictionary of PHP Environments
 
 The following properties are related when TLS/SSL is configured:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,7 @@ zabbix_web_memory_limit: 128M
 zabbix_web_post_max_size: 16M
 zabbix_web_upload_max_filesize: 2M
 zabbix_web_max_input_time: 300
+zabbix_apache_skip_custom_fragment: false
 
 zabbix_apache_SSLPassPhraseDialog: exec:/usr/libexec/httpd-ssl-pass-dialog
 zabbix_apache_SSLSessionCache: shmcb:/run/httpd/sslcache(512000)

--- a/templates/apache_vhost.conf.j2
+++ b/templates/apache_vhost.conf.j2
@@ -48,6 +48,7 @@
   RewriteEngine On
   RewriteRule ^$ /index.php [L]
 
+{% if zabbix_apache_skip_custom_fragment %}
   ## Custom fragment
   php_value max_execution_time {{ zabbix_web_max_execution_time | default('300') }}
   php_value memory_limit {{ zabbix_web_memory_limit | default('128M') }}
@@ -56,6 +57,7 @@
   php_value max_input_time {{ zabbix_web_max_input_time | default('300') }}
   # Set correct timezone.
   php_value date.timezone {{ zabbix_timezone }}
+{% endif %}
 </VirtualHost>
 
 {# Set up TLS vhosts #}


### PR DESCRIPTION
**Description of PR**

Added new zabbix_apache_skip_custom_fragment and if statement, to prevent php_value fields to be added to /etc/httpd/conf.d/zabbix.conf.

Default behavior is False, so no change there for all other users.. so you need to set the var to true for it to change behavior.

**Type of change**

Bugfix Pull Request

**Fixes an issue**

Fixes https://github.com/dj-wasabi/ansible-zabbix-web/issues/78