### PR TITLE
Correcting custom fragment PR 79

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_post_max_size`:
 * `zabbix_web_upload_max_filesize`:
 * `zabbix_web_max_input_time`:
-* `zabbix_apache_skip_custom_fragment`: True / False. Skips adding of php_value vars max_execution_time, memory_limit, post_max_size, upload_max_filesize, max_input_time and date.timezone in vhost file.. place those in php-fpm configuration. Default is false
+* `zabbix_apache_include_custom_fragment`: True / False. Includes php_value vars max_execution_time, memory_limit, post_max_size, upload_max_filesize, max_input_time and date.timezone in vhost file.. place those in php-fpm configuration. Default is true.
 * `zabbix_web_env`: (Optional) A Dictionary of PHP Environments
 
 The following properties are related when TLS/SSL is configured:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ zabbix_web_memory_limit: 128M
 zabbix_web_post_max_size: 16M
 zabbix_web_upload_max_filesize: 2M
 zabbix_web_max_input_time: 300
-zabbix_apache_skip_custom_fragment: false
+zabbix_apache_include_custom_fragment: true
 
 zabbix_apache_SSLPassPhraseDialog: exec:/usr/libexec/httpd-ssl-pass-dialog
 zabbix_apache_SSLSessionCache: shmcb:/run/httpd/sslcache(512000)

--- a/templates/apache_vhost.conf.j2
+++ b/templates/apache_vhost.conf.j2
@@ -48,7 +48,7 @@
   RewriteEngine On
   RewriteRule ^$ /index.php [L]
 
-{% if zabbix_apache_skip_custom_fragment %}
+{% if zabbix_apache_include_custom_fragment | default(true) %}
   ## Custom fragment
   php_value max_execution_time {{ zabbix_web_max_execution_time | default('300') }}
   php_value memory_limit {{ zabbix_web_memory_limit | default('128M') }}


### PR DESCRIPTION
**Description of PR**

zabbix_apache_skip_custom_fragment default value was false, which broke if the if statement
zabbix_apache_include_custom_fragment is set to true and the if statement does work

Corrects https://github.com/dj-wasabi/ansible-zabbix-web/pull/79

**Type of change**
Bugfix Pull Request

**Fixes an issue**

Earlier default was faulty, so changing name of param and correcting README