### PR TITLE
selinux blocking httpd connection to zabbix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,6 +63,16 @@
     - selinux_allow_zabbix_can_network
   tags: selinux
 
+- name: "Allow httpd to connect to zabbix (SELinux)"
+  seboolean:
+    name: httpd_can_connect_zabbix
+    persistent: yes
+    state: yes
+  when:
+    - ansible_selinux.status == "enabled"
+    - selinux_allow_zabbix_can_network
+  tags: selinux
+
 - name: "Allow httpd to connect to ldap (SELinux)"
   seboolean:
     name: httpd_can_connect_ldap


### PR DESCRIPTION
**Description of PR**
configure sebool to allow httpd to connect zabbix

**Type of change**

Bugfix Pull Request

**Fixes an issue**
Prevent error message on Zabbix web interface :
Zabbix server is not running: the information displayed may not be current.
