### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,14 @@
     - init
     - config
 
+- name: "Allow httpd to connect to zabbix (SELinux)"
+  seboolean:
+    name: httpd_can_connect_zabbix
+    persistent: yes
+    state: yes
+  when: ansible_selinux.status == "enabled"
+  tags: selinux
+
 - name: "Allow httpd to connect to db (SELinux)"
   seboolean:
     name: httpd_can_network_connect_db


### PR DESCRIPTION
In order to run zabbix-web in a standby-alone setup, we have to allow httpd to connect to zabbix.

**Description of PR**
SeLinux permissions for httpd -> zabbix connections. This is only applicable when you run a zabbix-web installation separated from zabbix-server.

**Type of change**
Feature Pull Request
