### PR TITLE
php-fpm, zabbix db schema and apachectl path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,7 @@ zabbix_server_dbname: zabbix-server
 zabbix_server_dbuser: zabbix-server
 zabbix_server_dbpassword: zabbix-server
 zabbix_server_dbport: 5432
+zabbix_server_dbschema:
 
 # Elasticsearch
 # zabbix_server_history_url:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ zabbix_apache_vhost_port: 80
 zabbix_apache_vhost_tls_port: 443
 zabbix_timezone: Europe/Amsterdam
 zabbix_vhost: True
+zabbix_php_fpm: False
 zabbix_apache_vhost_listen_ip: "*"
 zabbix_apache_tls: False
 zabbix_apache_redirect: False

--- a/tasks/apache.yml
+++ b/tasks/apache.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Apache | Get Apache version"
   shell: |
+    PATH=/usr/sbin:$PATH
     set -o pipefail
     apachectl -v | grep 'version' | awk -F '/' '{ print $2 }'| awk '{ print $1 }' | cut -c 1-3
   changed_when: False

--- a/templates/apache_vhost.conf.j2
+++ b/templates/apache_vhost.conf.j2
@@ -49,6 +49,10 @@
   RewriteRule ^$ /index.php [L]
 
   ## Custom fragment
+  {% if zabbix_php_fpm %}
+  ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/usr/share/zabbix/$1
+  ProxyTimeout 1800
+  {% else %}
   php_value max_execution_time {{ zabbix_web_max_execution_time | default('300') }}
   php_value memory_limit {{ zabbix_web_memory_limit | default('128M') }}
   php_value post_max_size {{ zabbix_web_post_max_size | default('16M') }}
@@ -56,6 +60,7 @@
   php_value max_input_time {{ zabbix_web_max_input_time | default('300') }}
   # Set correct timezone.
   php_value date.timezone {{ zabbix_timezone }}
+  {% endif %}
 </VirtualHost>
 
 {# Set up TLS vhosts #}
@@ -126,6 +131,10 @@ SSLCryptoDevice {{ zabbix_apache_SSLCryptoDevice }}
   RewriteRule ^$ /index.php [L]
 
   ## Custom fragment
+  {% if zabbix_php_fpm %}
+  ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://127.0.0.1:9000/usr/share/zabbix/$1
+  ProxyTimeout 1800
+  {% else %}
   php_value max_execution_time {{ zabbix_web_max_execution_time | default('300') }}
   php_value memory_limit {{ zabbix_web_memory_limit | default('128M') }}
   php_value post_max_size {{ zabbix_web_post_max_size | default('16M') }}
@@ -133,5 +142,6 @@ SSLCryptoDevice {{ zabbix_apache_SSLCryptoDevice }}
   php_value max_input_time {{ zabbix_web_max_input_time | default('300') }}
   # Set correct timezone.
   php_value date.timezone {{ zabbix_timezone }}
+  {% endif %}
 </VirtualHost>
 {% endif %}

--- a/templates/apache_vhost.conf.j2
+++ b/templates/apache_vhost.conf.j2
@@ -60,7 +60,7 @@
   php_value max_input_time {{ zabbix_web_max_input_time | default('300') }}
   # Set correct timezone.
   php_value date.timezone {{ zabbix_timezone }}
-  {% endif %}
+{% endif %}
 </VirtualHost>
 
 {# Set up TLS vhosts #}
@@ -142,6 +142,6 @@ SSLCryptoDevice {{ zabbix_apache_SSLCryptoDevice }}
   php_value max_input_time {{ zabbix_web_max_input_time | default('300') }}
   # Set correct timezone.
   php_value date.timezone {{ zabbix_timezone }}
-  {% endif %}
+{% endif %}
 </VirtualHost>
 {% endif %}

--- a/templates/zabbix.conf.php.j2
+++ b/templates/zabbix.conf.php.j2
@@ -13,8 +13,8 @@ $DB['DATABASE'] = '{{ zabbix_server_dbname }}';
 $DB['USER']     = '{{ zabbix_server_dbuser }}';
 $DB['PASSWORD'] = '{{ zabbix_server_dbpassword }}';
 
-// SCHEMA is relevant only for IBM_DB2 database
-$DB['SCHEMA'] = '';
+// Schema name. Used for IBM DB2 and PostgreSQL.
+$DB['SCHEMA'] = '{{ zabbix_server_dbschema }}';
 
 $ZBX_SERVER      = '{{ zabbix_server_hostname }}';
 $ZBX_SERVER_PORT = '{{ zabbix_server_listenport }}';


### PR DESCRIPTION
**Description of PR**
Allow the use of php-fpm insted of mod_php.

Allow the use of database schema and update the comment with the one in the latest version.

Add /usr/sbin to the PATH to look for apachectl command

**Type of change**
Feature Pull Request

**Fixes an issue**
